### PR TITLE
Prevent form submit

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     </div>
     <button id="admin-button">Admin</button>
     <div id="admin">
-      <form action="" id="admin-form">
+      <form action="" id="admin-form" onsubmit="event.preventDefault();">
         <label for="name">Name
           <input id="name" type="text" required>
         </label>

--- a/js/app.js
+++ b/js/app.js
@@ -55,8 +55,7 @@ let game = {
       name: document.getElementById('name').value,
       clicks: Number(document.getElementById('clicks').value),
       src: document.getElementById('url').value
-    });
-    debugger
+    }); 
     catListView.render();
   }
 };
@@ -107,13 +106,13 @@ let catListView = {
       elem.textContent = cat.name;
 
       /*listen to click: set current cat and display it. closure trick to link cat variable to the click event function*/
-      elem.addEventListener('click', (function(catCopy) {
-        return function() {
-          game.setCurrentCat(catCopy);
-          catView.render();
-        };
-      })(cat));
+      const catButtonClick = function () {
+        game.setCurrentCat(cat);
+        catView.render();
+      }
 
+
+      elem.addEventListener('click', catButtonClick);
       //add button to HTML
       this.catListElem.appendChild(elem);
     }


### PR DESCRIPTION
The cat was not added, because the `<form>` was submitted when you clicked the buttons in the admin area. So all you needed to do was to prevent the default handler. I did it directly in html, but you could do it also in javascript as `document.getElementById('admin-form').addEventListener('submit', (e) => e.preventDefault(), false);`. 

Also, I simplified a bit the cat button click handler as closure would work even without the wrapper function, because `cat` variable is already scoped to the loop body